### PR TITLE
Add linting and formatting with Ruff

### DIFF
--- a/crypto_lambda/etl.py
+++ b/crypto_lambda/etl.py
@@ -8,8 +8,8 @@ from crypto_lambda import load
 
 coins = ["bitcoin", "ethereum", "tether", "binancecoin", "solana"]
 
-def lambda_handler(event, context):
 
+def lambda_handler(event, context):
     bucket_name = os.environ.get("CRYPTO_DATA_BUCKET")
     print(f"Fetching data for: {', '.join(coins)}")
 
@@ -21,7 +21,7 @@ def lambda_handler(event, context):
         return {"statusCode": 500, "body": "Failed to fetch data"}
 
     timestamp = datetime.now(timezone.utc).isoformat()
-    s3 = boto3.client('s3')
+    s3 = boto3.client("s3")
     success_count_raw = 0
     success_count_processed = 0
 
@@ -36,7 +36,7 @@ def lambda_handler(event, context):
         raw_record = {
             "coin": coin,
             "price_usd": price_info["usd"],
-            "timestamp": timestamp
+            "timestamp": timestamp,
         }
 
         raw_file_name = f"raw/{coin}_{timestamp}.json"
@@ -45,7 +45,7 @@ def lambda_handler(event, context):
                 Bucket=bucket_name,
                 Key=raw_file_name,
                 Body=json.dumps(raw_record),
-                ContentType='application/json'
+                ContentType="application/json",
             )
             print(f"Stored RAW {coin} to {bucket_name}/{raw_file_name}")
             success_count_raw += 1
@@ -73,7 +73,7 @@ def lambda_handler(event, context):
                 Bucket=bucket_name,
                 Key=processed_file_name,
                 Body=json.dumps(record),
-                ContentType='application/json'
+                ContentType="application/json",
             )
             print(f"Stored PROCESSED {coin} to {bucket_name}/{processed_file_name}")
             success_count_processed += 1
@@ -92,9 +92,9 @@ def lambda_handler(event, context):
 
     # Determine weather the success was full or partial
     partial_failure = (
-    success_count_raw < len(coins)
-    or success_count_processed < len(coins)
-    or loading == "FAIL"
+        success_count_raw < len(coins)
+        or success_count_processed < len(coins)
+        or loading == "FAIL"
     )
 
     status = 207 if partial_failure else 200
@@ -102,8 +102,8 @@ def lambda_handler(event, context):
     return {
         "statusCode": status,
         "body": (
-        f"Stored raw: {success_count_raw}, "
-        f"processed: {success_count_processed} out of {len(coins)} coins. "
-        f"Load to database = {loading}"
-        )
+            f"Stored raw: {success_count_raw}, "
+            f"processed: {success_count_processed} out of {len(coins)} coins. "
+            f"Load to database = {loading}"
+        ),
     }

--- a/crypto_lambda/extract.py
+++ b/crypto_lambda/extract.py
@@ -1,5 +1,6 @@
 import requests
 
+
 def extract_data(coins):
     coin_ids = ",".join(coins)
     url = f"https://api.coingecko.com/api/v3/simple/price?ids={coin_ids}&vs_currencies=usd"

--- a/crypto_lambda/init_schema.py
+++ b/crypto_lambda/init_schema.py
@@ -1,7 +1,10 @@
 import os
 
+
 def ensure_table_exists(conn):
-    schema_path = os.path.join(os.path.dirname(__file__), "lambda_sql", "create_schema.sql")
+    schema_path = os.path.join(
+        os.path.dirname(__file__), "lambda_sql", "create_schema.sql"
+    )
     with open(schema_path, "r") as f:
         schema_sql = f.read()
     try:

--- a/crypto_lambda/load.py
+++ b/crypto_lambda/load.py
@@ -13,7 +13,7 @@ DB_PASSWORD = os.getenv("DB_PASSWORD")
 TABLE_NAME = os.getenv("TABLE_NAME")
 
 # Loading SQL insert statement - !!FOR TESTING!! - local path
-#with open("../lambda/lambda_sql/insert_coin.sql", "r") as f:
+# with open("../lambda/lambda_sql/insert_coin.sql", "r") as f:
 
 # Loading SQL insert statement - !!FOR PRODUCTION!! - lambda deploment env relative path
 sql_path = os.path.join(os.path.dirname(__file__), "lambda_sql", "insert_coin.sql")
@@ -23,9 +23,9 @@ with open(sql_path, "r") as f:
 INSERT_SQL = raw_sql.replace("{{TABLE_NAME}}", TABLE_NAME)
 print(f"\n🧾 Final SQL being run:\n{INSERT_SQL}\n")
 
+
 # Loading coin records to DB
 def load_data(records):
-
     print(f"Starting load of {len(records)} records")
 
     try:
@@ -67,9 +67,10 @@ def load_data(records):
 
         conn.commit()
     finally:
-        if 'conn' in locals():
+        if "conn" in locals():
             conn.close()
             print("Connection successfully closed")
+
 
 # For local DB testing
 if __name__ == "__main__":

--- a/crypto_lambda/transform.py
+++ b/crypto_lambda/transform.py
@@ -1,17 +1,16 @@
 from datetime import datetime, timezone
 
+
 def transform_data(data):
-    """ Returns a list of dict: Transformed list of coin data with coin name, price, and timestamp. """
+    """Returns a list of dict: Transformed list of coin data with coin name, price, and timestamp."""
 
     timestamp = datetime.now(timezone.utc).isoformat()
     transformed_list = []
 
     for coin, record in data.items():
         if record and "price_usd" in record:
-            transformed_list.append({
-                "coin": coin,
-                "price_usd": record["price_usd"],
-                "timestamp": timestamp
-            })
+            transformed_list.append(
+                {"coin": coin, "price_usd": record["price_usd"], "timestamp": timestamp}
+            )
 
     return transformed_list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,10 @@
 [tool.ruff]
-
 # Maximum line length for readability and future Black alignment
 line-length = 88
 
 [tool.ruff.lint]
-
 # Linting categories: Errors, Warnings, Complexity, Naming, Pyflakes-style issues
 select = ["E", "F", "W", "C", "N"]
-
 # Folders and files to exclude from linting
 exclude = [
     ".pytest_cache/",
@@ -18,3 +15,5 @@ exclude = [
     "zip_lambda.sh",
     "update_aws_keys.sh"
 ]
+
+[tool.ruff.format]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,4 +2,4 @@ import sys
 import os
 
 # Add the project root to sys.path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -9,7 +9,7 @@ env_vars = {
     "DB_NAME": "testdb",
     "DB_USER": "user",
     "DB_PASSWORD": "pass",
-    "TABLE_NAME": "coins"
+    "TABLE_NAME": "coins",
 }
 # Patch in fake env vars before load.py attempts to find them in Terraform
 with patch.dict(os.environ, env_vars):
@@ -26,16 +26,21 @@ def test_lambda_handler_success():
     # Mock transformed output data
     mock_transformed = [
         {"coin": "bitcoin", "price_usd": 100, "timestamp": "ts"},
-        {"coin": "ethereum", "price_usd": 200, "timestamp": "ts"}
+        {"coin": "ethereum", "price_usd": 200, "timestamp": "ts"},
     ]
 
     mock_s3 = MagicMock()
 
     with patch("crypto_lambda.etl.extract.extract_data", return_value=mock_extract):
-        with patch("crypto_lambda.etl.transform.transform_data", return_value=mock_transformed):
+        with patch(
+            "crypto_lambda.etl.transform.transform_data", return_value=mock_transformed
+        ):
             with patch("crypto_lambda.etl.load.load_data") as mock_load:
                 with patch("crypto_lambda.etl.boto3.client", return_value=mock_s3):
-                    with patch("crypto_lambda.etl.os.environ", {"CRYPTO_DATA_BUCKET": "mybucket"}):
+                    with patch(
+                        "crypto_lambda.etl.os.environ",
+                        {"CRYPTO_DATA_BUCKET": "mybucket"},
+                    ):
                         with patch("crypto_lambda.etl.coins", ["bitcoin", "ethereum"]):
                             result = etl.lambda_handler(event, context)
 
@@ -57,15 +62,21 @@ def test_lambda_handler_success():
     # DB load called with full transformed list
     mock_load.assert_called_once_with(mock_transformed)
 
+
 def test_lambda_handler_extract_failure():
     event = {}
     context = {}
 
-    with patch("crypto_lambda.etl.extract.extract_data", side_effect=Exception("API down")):
+    with patch(
+        "crypto_lambda.etl.extract.extract_data", side_effect=Exception("API down")
+    ):
         with patch("crypto_lambda.etl.boto3.client") as mock_s3:
             with patch("crypto_lambda.etl.transform.transform_data") as mock_transform:
                 with patch("crypto_lambda.etl.load.load_data") as mock_load:
-                    with patch("crypto_lambda.etl.os.environ", {"CRYPTO_DATA_BUCKET": "mybucket"}):
+                    with patch(
+                        "crypto_lambda.etl.os.environ",
+                        {"CRYPTO_DATA_BUCKET": "mybucket"},
+                    ):
                         result = etl.lambda_handler(event, context)
 
     # Assertions
@@ -76,6 +87,7 @@ def test_lambda_handler_extract_failure():
     mock_s3.assert_not_called()
     mock_transform.assert_not_called()
     mock_load.assert_not_called()
+
 
 def test_lambda_handler_partial_raw_s3_failure():
     event = {}
@@ -90,7 +102,7 @@ def test_lambda_handler_partial_raw_s3_failure():
     mock_s3.put_object.side_effect = [
         Exception("S3 fail"),     # raw bitcoin fail
         None,                     # raw ethereum success
-        None                      # Dummy processed coin success
+        None,                     # Dummy processed coin success
     ]
 
     with patch("crypto_lambda.etl.extract.extract_data", return_value=mock_extracted):
@@ -100,9 +112,15 @@ def test_lambda_handler_partial_raw_s3_failure():
             mock_datetime.timezone = timezone
 
             with patch("crypto_lambda.etl.boto3.client", return_value=mock_s3):
-                with patch("crypto_lambda.etl.transform.transform_data", return_value=[{"coin": "dummy"}]) as mock_transform:
+                with patch(
+                    "crypto_lambda.etl.transform.transform_data",
+                    return_value=[{"coin": "dummy"}],
+                ) as mock_transform:
                     with patch("crypto_lambda.etl.load.load_data") as mock_load:
-                        with patch("crypto_lambda.etl.os.environ", {"CRYPTO_DATA_BUCKET": "mybucket"}):
+                        with patch(
+                            "crypto_lambda.etl.os.environ",
+                            {"CRYPTO_DATA_BUCKET": "mybucket"},
+                        ):
                             result = etl.lambda_handler(event, context)
 
     # Assertions
@@ -110,7 +128,10 @@ def test_lambda_handler_partial_raw_s3_failure():
     assert "Stored raw: 1, processed: 1" in result["body"]  # Single raw success
 
     # Raw filenames form correctly
-    assert mock_s3.put_object.call_args_list[1].kwargs["Key"] == f"raw/ethereum_{timestamp}.json"
+    assert (
+        mock_s3.put_object.call_args_list[1].kwargs["Key"]
+        == f"raw/ethereum_{timestamp}.json"
+    )
 
     # Transform receives only successful raw records
     mock_transform.assert_called_once()
@@ -120,22 +141,26 @@ def test_lambda_handler_partial_raw_s3_failure():
     # Check the program continues after call to transform
     mock_load.assert_called_once_with([{"coin": "dummy"}])
 
+
 def test_lambda_handler_transform_failure():
     event = {}
     context = {}
 
     # Mock extract → valid data
-    mock_extracted = {
-        "bitcoin": {"usd": 50000},
-        "ethereum": {"usd": 3500}
-    }
+    mock_extracted = {"bitcoin": {"usd": 50000}, "ethereum": {"usd": 3500}}
 
     with patch("crypto_lambda.etl.extract.extract_data", return_value=mock_extracted):
         mock_s3 = MagicMock()
         with patch("crypto_lambda.etl.boto3.client", return_value=mock_s3):
-            with patch("crypto_lambda.etl.transform.transform_data", side_effect=Exception("Transform fail")) as mock_transform:
+            with patch(
+                "crypto_lambda.etl.transform.transform_data",
+                side_effect=Exception("Transform fail"),
+            ) as mock_transform:
                 with patch("crypto_lambda.etl.load.load_data") as mock_load:
-                    with patch("crypto_lambda.etl.os.environ", {"CRYPTO_DATA_BUCKET": "mybucket"}):
+                    with patch(
+                        "crypto_lambda.etl.os.environ",
+                        {"CRYPTO_DATA_BUCKET": "mybucket"},
+                    ):
                         result = etl.lambda_handler(event, context)
 
     # Assertions
@@ -146,6 +171,7 @@ def test_lambda_handler_transform_failure():
     mock_load.assert_not_called()
     assert mock_s3.put_object.call_count == 2  # only raw S3 writes
 
+
 def test_lambda_handler_partial_processed_s3_failure():
     event = {}
     context = {}
@@ -153,7 +179,7 @@ def test_lambda_handler_partial_processed_s3_failure():
 
     mock_transformed = [
         {"coin": "bitcoin", "price_usd": 100, "timestamp": timestamp},
-        {"coin": "ethereum", "price_usd": 200, "timestamp": timestamp}
+        {"coin": "ethereum", "price_usd": 200, "timestamp": timestamp},
     ]
 
     # Mock S3
@@ -162,19 +188,30 @@ def test_lambda_handler_partial_processed_s3_failure():
         None,                   # raw bitcoin success
         None,                   # raw ethereum success
         Exception("S3 fail"),   # processed bitcoin fail
-        None                    # processed ethereum success
+        None,                   # processed ethereum success
     ]
 
-    with patch("crypto_lambda.etl.extract.extract_data", return_value={"bitcoin": {"usd": 0}, "ethereum": {"usd": 0}}):
+    with patch(
+        "crypto_lambda.etl.extract.extract_data",
+        return_value={"bitcoin": {"usd": 0}, "ethereum": {"usd": 0}},
+    ):
         with patch("crypto_lambda.etl.datetime") as mock_datetime:
             mock_datetime.now.return_value = datetime.fromisoformat(timestamp)
             mock_datetime.timezone = timezone
 
             with patch("crypto_lambda.etl.boto3.client", return_value=mock_s3):
-                with patch("crypto_lambda.etl.transform.transform_data", return_value=mock_transformed):
+                with patch(
+                    "crypto_lambda.etl.transform.transform_data",
+                    return_value=mock_transformed,
+                ):
                     with patch("crypto_lambda.etl.load.load_data") as mock_load:
-                        with patch("crypto_lambda.etl.os.environ", {"CRYPTO_DATA_BUCKET": "mybucket"}):
-                            with patch("crypto_lambda.etl.coins", ["bitcoin", "ethereum"]):
+                        with patch(
+                            "crypto_lambda.etl.os.environ",
+                            {"CRYPTO_DATA_BUCKET": "mybucket"},
+                        ):
+                            with patch(
+                                "crypto_lambda.etl.coins", ["bitcoin", "ethereum"]
+                            ):
                                 result = etl.lambda_handler(event, context)
 
     # Assertions -
@@ -182,10 +219,14 @@ def test_lambda_handler_partial_processed_s3_failure():
     assert "Stored raw: 2, processed: 1" in result["body"]  # Single processed success
 
     # Raw filenames form correctly
-    assert mock_s3.put_object.call_args_list[3].kwargs["Key"] == f"processed/ethereum_{timestamp}.json"
+    assert (
+        mock_s3.put_object.call_args_list[3].kwargs["Key"]
+        == f"processed/ethereum_{timestamp}.json"
+    )
 
     # Load is still called
     mock_load.assert_called_once()
+
 
 def test_lambda_handler_load_failure():
     event = {}
@@ -194,17 +235,24 @@ def test_lambda_handler_load_failure():
     mock_extracted = {"bitcoin": {"usd": 100}, "ethereum": {"usd": 200}}
     mock_transformed = [
         {"coin": "bitcoin", "price_usd": 100, "timestamp": "ts"},
-        {"coin": "ethereum", "price_usd": 200, "timestamp": "ts"}
+        {"coin": "ethereum", "price_usd": 200, "timestamp": "ts"},
     ]
 
     mock_s3 = MagicMock()
     mock_s3.put_object.side_effect = [None, None, None, None]
 
     with patch("crypto_lambda.etl.extract.extract_data", return_value=mock_extracted):
-        with patch("crypto_lambda.etl.transform.transform_data", return_value=mock_transformed):
-            with patch("crypto_lambda.etl.load.load_data", side_effect=Exception("DB fail")):
+        with patch(
+            "crypto_lambda.etl.transform.transform_data", return_value=mock_transformed
+        ):
+            with patch(
+                "crypto_lambda.etl.load.load_data", side_effect=Exception("DB fail")
+            ):
                 with patch("crypto_lambda.etl.boto3.client", return_value=mock_s3):
-                    with patch("crypto_lambda.etl.os.environ", {"CRYPTO_DATA_BUCKET": "mybucket"}):
+                    with patch(
+                        "crypto_lambda.etl.os.environ",
+                        {"CRYPTO_DATA_BUCKET": "mybucket"},
+                    ):
                         result = etl.lambda_handler(event, context)
 
     # Assertions

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 from crypto_lambda import extract
 
+
 def test_extract_data_success(monkeypatch):
     # Define fake API response
     fake_response = {"bitcoin": {"usd": 45000}}
@@ -10,6 +11,7 @@ def test_extract_data_success(monkeypatch):
     class MockResponse:
         def raise_for_status(self):  # Simulate successful status
             pass
+
         def json(self):  # Simulate JSON response
             return fake_response
 
@@ -39,11 +41,13 @@ def test_extract_data_http_error(monkeypatch):
     with pytest.raises(requests.HTTPError):
         extract.extract_data(["bitcoin", "ethereum"])
 
+
 def test_extract_data_malformed_json(monkeypatch):
     # Mock response to return malformed JSON (e.g., missing expected keys)
     class MockResponse:
         def raise_for_status(self):
             pass  # Simulate 200 OK
+
         def json(self):
             return {"unexpected_key": "oops"}  # Malformed structure
 
@@ -56,11 +60,13 @@ def test_extract_data_malformed_json(monkeypatch):
     result = extract.extract_data(["bitcoin", "ethereum"])
     assert result == {"unexpected_key": "oops"}
 
+
 def test_extract_data_empty_json(monkeypatch):
     # Mock response to return empty JSON
     class MockResponse:
         def raise_for_status(self):
             pass
+
         def json(self):
             return {}
 

--- a/tests/test_init_schema.py
+++ b/tests/test_init_schema.py
@@ -1,9 +1,9 @@
-import pytest   # noqa: F401
+import pytest  # noqa: F401
 from unittest.mock import Mock
 from crypto_lambda.init_schema import ensure_table_exists
 
-def test_ensure_table_exists_success():
 
+def test_ensure_table_exists_success():
     # Create conn object
     mock_conn = Mock()
 
@@ -15,8 +15,8 @@ def test_ensure_table_exists_success():
     args = mock_conn.run.call_args[0][0]
     assert "CREATE TABLE" in args
 
-def test_ensure_table_exists_failure(capsys):
 
+def test_ensure_table_exists_failure(capsys):
     # Create conn object and cause exception
     mock_conn = Mock()
     mock_conn.run.side_effect = Exception("some failure")

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,4 +1,4 @@
-import pytest   # noqa: F401
+import pytest  # noqa: F401
 import os
 from unittest.mock import MagicMock, patch
 
@@ -9,17 +9,25 @@ env_vars = {
     "DB_NAME": "testdb",
     "DB_USER": "user",
     "DB_PASSWORD": "pass",
-    "TABLE_NAME": "coins"
+    "TABLE_NAME": "coins",
 }
 # Patch in fake env vars before load.py attempts to find them in Terraform
 with patch.dict(os.environ, env_vars):
     from crypto_lambda import load
 
-def test_load_data_success():
 
+def test_load_data_success():
     records = [
-        {"coin": "bitcoin", "price_usd": 50000, "timestamp": "2025-11-25T12:00:00+00:00"},
-        {"coin": "ethereum", "price_usd": 3500, "timestamp": "2025-11-25T12:00:00+00:00"}
+        {
+            "coin": "bitcoin",
+            "price_usd": 50000,
+            "timestamp": "2025-11-25T12:00:00+00:00",
+        },
+        {
+            "coin": "ethereum",
+            "price_usd": 3500,
+            "timestamp": "2025-11-25T12:00:00+00:00",
+        },
     ]
 
     # Create a mock cursor
@@ -51,9 +59,15 @@ def test_load_data_success():
     assert btc_params == ("bitcoin", 50000, "2025-11-25T12:00:00+00:00", "Tuesday")
     assert eth_params == ("ethereum", 3500, "2025-11-25T12:00:00+00:00", "Tuesday")
 
-def test_load_data_db_connection_failure():
 
-    records = [{"coin": "bitcoin", "price_usd": 50000, "timestamp": "2025-11-25T12:00:00+00:00"}]
+def test_load_data_db_connection_failure():
+    records = [
+        {
+            "coin": "bitcoin",
+            "price_usd": 50000,
+            "timestamp": "2025-11-25T12:00:00+00:00",
+        }
+    ]
 
     # Patch pg8000.connect to raise an exception (simulating DB down)
     with patch("crypto_lambda.load.pg8000.connect", side_effect=Exception("DB down")):
@@ -61,10 +75,19 @@ def test_load_data_db_connection_failure():
         with patch("crypto_lambda.load.ensure_table_exists") as mock_ensure:
             load.load_data(records)
 
+
 def test_load_data_insert_failure():
     records = [
-        {"coin": "bitcoin", "price_usd": 50000, "timestamp": "2025-11-25T12:00:00+00:00"},
-        {"coin": "ethereum", "price_usd": 3500, "timestamp": "2025-11-25T12:00:00+00:00"}
+        {
+            "coin": "bitcoin",
+            "price_usd": 50000,
+            "timestamp": "2025-11-25T12:00:00+00:00",
+        },
+        {
+            "coin": "ethereum",
+            "price_usd": 3500,
+            "timestamp": "2025-11-25T12:00:00+00:00",
+        },
     ]
 
     mock_cursor = MagicMock()
@@ -75,6 +98,7 @@ def test_load_data_insert_failure():
     def execute_side_effect(sql, params):
         if params[0] != "ethereum":
             raise Exception("Insert failed")
+
     mock_cursor.execute.side_effect = execute_side_effect
 
     with patch("crypto_lambda.load.pg8000.connect", return_value=mock_conn):
@@ -86,10 +110,15 @@ def test_load_data_insert_failure():
     mock_conn.commit.assert_called_once()
     mock_conn.close.assert_called_once()
 
+
 def test_load_data_bad_timestamp():
     records = [
         {"coin": "bitcoin", "price_usd": 50000, "timestamp": "NAUGHTY_TIMESTAMP"},
-        {"coin": "ethereum", "price_usd": 3500, "timestamp": "2025-11-25T12:00:00+00:00"}
+        {
+            "coin": "ethereum",
+            "price_usd": 3500,
+            "timestamp": "2025-11-25T12:00:00+00:00",
+        },
     ]
 
     mock_cursor = MagicMock()
@@ -106,6 +135,7 @@ def test_load_data_bad_timestamp():
     assert executed_params[0] == "ethereum"
     mock_conn.commit.assert_called_once()
     mock_conn.close.assert_called_once()
+
 
 def test_load_data_empty_records():
     records = []

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,5 +1,6 @@
 from crypto_lambda import transform
 
+
 def test_transform_data_success():
     input_data = {
         "bitcoin": {"price_usd": 50000},
@@ -27,12 +28,13 @@ def test_transform_data_success():
     timestamps = {item["timestamp"] for item in result}
     assert len(timestamps) == 1
 
+
 def test_transform_data_skips_invalid():
     input_data = {
-        "bitcoin": {"price_usd": 50000},   # valid
+        "bitcoin": {"price_usd": 50000},    # valid
         "ethereum": {},                     # empty dict → skipped
         "solana": None,                     # None → skipped
-        "tether": {"usd": 1.0}              # missing price_usd → skipped
+        "tether": {"usd": 1.0},             # missing price_usd → skipped
     }
 
     result = transform.transform_data(input_data)
@@ -41,4 +43,3 @@ def test_transform_data_skips_invalid():
     assert len(result) == 1
     assert result[0]["coin"] == "bitcoin"
     assert result[0]["price_usd"] == 50000
-


### PR DESCRIPTION
### Summary
This PR introduces static linting and formatting to the ETL project using Ruff. It establishes a clean, professional baseline for style and mechanical correctness.

### Changes
- Added `pyproject.toml` configuration for Ruff
- Applied safe auto-fixes to existing code
- Cleaned up trailing whitespace and line length violations with ruff formatting
- Committed configuration and fixes in separate, logical commits

### CI Integration
- Ruff is now integrated into CI to fail builds on lint violations
- Ensures consistent style enforcement across all future development

Closes #11 