### PR TITLE
Adding ruff check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
+      - name: Run Ruff
+        run: ruff check .
+
       - name: Run tests (with coverage)
         run: |
           pytest --cov=crypto_lambda --cov-report=term-missing -v --cov-fail-under=80

--- a/crypto_lambda/transform.py
+++ b/crypto_lambda/transform.py
@@ -2,7 +2,10 @@ from datetime import datetime, timezone
 
 
 def transform_data(data):
-    """Returns a list of dict: Transformed list of coin data with coin name, price, and timestamp."""
+    """
+    Returns a list of dicts:
+    Transformed coin data with coin name, price, and timestamp
+    """
 
     timestamp = datetime.now(timezone.utc).isoformat()
     transformed_list = []

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
-pytest
-pytest-cov
+pytest==8.3.4
+pytest-cov==5.0.0
+ruff==0.6.9

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -155,7 +155,7 @@ def test_lambda_handler_transform_failure():
             with patch(
                 "crypto_lambda.etl.transform.transform_data",
                 side_effect=Exception("Transform fail"),
-            ) as mock_transform:
+            ) as _mock_transform:
                 with patch("crypto_lambda.etl.load.load_data") as mock_load:
                     with patch(
                         "crypto_lambda.etl.os.environ",

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -56,7 +56,8 @@ def test_extract_data_malformed_json(monkeypatch):
 
     monkeypatch.setattr(requests, "get", mock_get)
 
-    # The function should return what the API gave; downstream code should handle unexpected keys
+    # Function should return what the API gave;
+    # downstream code should handle unexpected keys
     result = extract.extract_data(["bitcoin", "ethereum"])
     assert result == {"unexpected_key": "oops"}
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -72,7 +72,7 @@ def test_load_data_db_connection_failure():
     # Patch pg8000.connect to raise an exception (simulating DB down)
     with patch("crypto_lambda.load.pg8000.connect", side_effect=Exception("DB down")):
         # Patch ensure_table_exists to assert downstream code is not called
-        with patch("crypto_lambda.load.ensure_table_exists") as mock_ensure:
+        with patch("crypto_lambda.load.ensure_table_exists") as _mock_ensure:
             load.load_data(records)
 
 


### PR DESCRIPTION
Add Ruff linting to CI workflow

- Installs Ruff via requirements-dev.txt
- Runs Ruff using pyproject.toml configuration
- Ensures code style and linting are enforced on every push and PR
- Keeps existing pytest coverage checks intact
